### PR TITLE
fix: common split

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -21,7 +21,7 @@ pub fn read_gpx(path: &str) -> Result<Gpx, Error> {
 /// Writes the Gpx into a new file pased on the given path
 /// while appending the counter to the filename.
 ///
-pub fn write_gpx(gpx: Gpx, path: &String, counter: usize) -> Result<(), Error> {
+pub fn write_gpx(gpx: Gpx, path: &str, counter: usize) -> Result<(), Error> {
     let p = create_path(path, counter)?;
     let file = File::create(p)?;
         let res = write(&gpx, file);
@@ -33,7 +33,7 @@ pub fn write_gpx(gpx: Gpx, path: &String, counter: usize) -> Result<(), Error> {
 
 /// creates a new path to a file
 ///
-fn create_path(path: &String, counter: usize) -> Result<String, Error> {
+fn create_path(path: &str, counter: usize) -> Result<String, Error> {
     let parts: Vec<&str> = path.rsplitn(2, '.').collect();
     if parts.len() != 2 {
         return Err(Error::new(ErrorKind::InvalidInput, format!("invalid file: {}", path)));
@@ -50,6 +50,6 @@ fn to_error(gpx_err: GpxError) -> Error {
 
 #[test]
 fn test_create_path() {
-    let res = create_path(&"foo/bar.gpx".to_string(), 1).unwrap();
+    let res = create_path(&"foo/bar.gpx", 1).unwrap();
     assert_eq!("foo/bar_1.gpx", res);
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -50,6 +50,6 @@ fn to_error(gpx_err: GpxError) -> Error {
 
 #[test]
 fn test_create_path() {
-    let res = create_path(&"foo/bar.gpx", 1).unwrap();
+    let res = create_path("foo/bar.gpx", 1).unwrap();
     assert_eq!("foo/bar_1.gpx", res);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use clap::{Parser, ValueEnum};
 use log::info;
 
-use gpx_split::split::{Splitter, TrackSplitter, RouteSplitter};
+use gpx_split::split::{Splitter, TrackSplitter, RouteSplitter, Context};
 use gpx_split::limit::{LengthLimit, PointsLimit, Limit};
 
 
@@ -55,8 +55,8 @@ fn main() {
 
     let limit = create_limit(max, by);
     let res = match trace {
-        Trace::Route => run(RouteSplitter::new(path, limit)),
-        Trace::Track => run(TrackSplitter::new(path, limit)),
+        Trace::Route => run(path.clone(), Box::new(RouteSplitter::new(path, limit))),
+        Trace::Track => run(path.clone(), Box::new(TrackSplitter::new(path, limit))),
     };
     res.unwrap();
 
@@ -70,6 +70,7 @@ fn create_limit(max: u32, by: By) -> Box<dyn Limit> {
     }
 }
 
-fn run<T: Splitter>(splitter: T) -> Result<usize, Error> {
-    splitter.split()
+fn run<T: 'static>(path: String, splitter: Box<dyn Splitter<T>>) -> Result<usize, Error> {
+    let c = Context::new(path, splitter);
+    c.run()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,8 +55,8 @@ fn main() {
 
     let limit = create_limit(max, by);
     let res = match trace {
-        Trace::Route => run(path.clone(), Box::new(RouteSplitter::new(path, limit))),
-        Trace::Track => run(path.clone(), Box::new(TrackSplitter::new(path, limit))),
+        Trace::Route => run(path.clone(), Box::new(RouteSplitter::new(limit))),
+        Trace::Track => run(path.clone(), Box::new(TrackSplitter::new(limit))),
     };
     res.unwrap();
 

--- a/src/split.rs
+++ b/src/split.rs
@@ -68,13 +68,13 @@ impl Splitter<Route> for RouteSplitter {
     /// Writes the given route(s) into new files, when there are more than one route.
     /// If there is only one route, we did not split anything, so no need to write.
     ///
-    fn write(&self, path: &String, gpx: &Gpx, routes: Vec<Route>) -> Result<usize, Error> {
-        for (index, route) in routes.iter().enumerate() {
+    fn write(&self, path: &String, gpx: &Gpx, new_routes: Vec<Route>) -> Result<usize, Error> {
+        for (index, route) in new_routes.iter().enumerate() {
             let clone = self.clone_gpx(gpx, route);
             write_gpx(clone, path, index)?
         }
 
-        Ok(routes.len())
+        Ok(new_routes.len())
     }
 }
 
@@ -121,10 +121,10 @@ impl RouteSplitter {
         cloned_route
     }
 
-    fn clone_gpx(&self, src_gpx: &Gpx, trace: &Route) -> Gpx {
-        let mut gpx = fit_bounds(src_gpx.clone(), &trace.points);
+    fn clone_gpx(&self, src_gpx: &Gpx, route: &Route) -> Gpx {
+        let mut gpx = fit_bounds(src_gpx.clone(), &route.points);
         gpx.routes.clear();
-        gpx.routes.push(trace.to_owned());
+        gpx.routes.push(route.to_owned());
         gpx
     }
 }
@@ -144,13 +144,13 @@ impl Splitter<Track> for TrackSplitter {
     /// Writes the given tracks into new files, when there are more than one route.
     /// If there is only one track, we did not split anything, so no need to write.
     ///
-    fn write(&self, path: &String, gpx: &Gpx, new_traces: Vec<Track>) -> Result<usize, Error> {
-        for (index, track) in new_traces.iter().enumerate() {
+    fn write(&self, path: &String, gpx: &Gpx, new_tracks: Vec<Track>) -> Result<usize, Error> {
+        for (index, track) in new_tracks.iter().enumerate() {
             let clone = self.clone_gpx(gpx, track);
             write_gpx(clone, path, index)?;
         }
 
-        Ok(new_traces.len())
+        Ok(new_tracks.len())
     }
 }
 

--- a/src/split.rs
+++ b/src/split.rs
@@ -38,7 +38,7 @@ impl<T> Context<T> {
 pub trait Splitter<T> {
     fn traces(&self, gpx: Gpx) -> Vec<T>;
     fn split(&self, origin: Vec<T>) -> Vec<T>;
-    fn write(&self, path: &String, gpx: &Gpx, new_traces: Vec<T>) -> Result<usize, Error>;
+    fn write(&self, path: &str, gpx: &Gpx, new_traces: Vec<T>) -> Result<usize, Error>;
 }
 
 /// Splitter for routes.
@@ -68,7 +68,7 @@ impl Splitter<Route> for RouteSplitter {
     /// Writes the given route(s) into new files, when there are more than one route.
     /// If there is only one route, we did not split anything, so no need to write.
     ///
-    fn write(&self, path: &String, gpx: &Gpx, new_routes: Vec<Route>) -> Result<usize, Error> {
+    fn write(&self, path: &str, gpx: &Gpx, new_routes: Vec<Route>) -> Result<usize, Error> {
         for (index, route) in new_routes.iter().enumerate() {
             let clone = self.clone_gpx(gpx, route);
             write_gpx(clone, path, index)?
@@ -144,7 +144,7 @@ impl Splitter<Track> for TrackSplitter {
     /// Writes the given tracks into new files, when there are more than one route.
     /// If there is only one track, we did not split anything, so no need to write.
     ///
-    fn write(&self, path: &String, gpx: &Gpx, new_tracks: Vec<Track>) -> Result<usize, Error> {
+    fn write(&self, path: &str, gpx: &Gpx, new_tracks: Vec<Track>) -> Result<usize, Error> {
         for (index, track) in new_tracks.iter().enumerate() {
             let clone = self.clone_gpx(gpx, track);
             write_gpx(clone, path, index)?;

--- a/tests/split_it.rs
+++ b/tests/split_it.rs
@@ -4,7 +4,7 @@ use gpx_split::limit::{LengthLimit, PointsLimit};
 #[test]
 fn test_track_length() {
     let path = "target/debug/track_l.gpx".to_string();
-    let splitter = Box::new(TrackSplitter::new(path.clone(),
+    let splitter = Box::new(TrackSplitter::new(
         Box::new(LengthLimit::new(1000))));
 
     let ctx = Context::new(path, splitter);
@@ -16,7 +16,7 @@ fn test_track_length() {
 #[test]
 fn test_track_points() {
     let path = "target/debug/track_p.gpx".to_string();
-    let splitter = Box::new(TrackSplitter::new(path.clone(),
+    let splitter = Box::new(TrackSplitter::new(
     Box::new(PointsLimit::new(50))));
 
     let ctx = Context::new(path, splitter);
@@ -28,7 +28,7 @@ fn test_track_points() {
 #[test]
 fn test_route_length() {
     let path = "target/debug/route_l.gpx".to_string();
-    let splitter = Box::new(RouteSplitter::new(path.clone(),
+    let splitter = Box::new(RouteSplitter::new(
     Box::new(LengthLimit::new(5000))));
 
     let ctx = Context::new(path, splitter);
@@ -40,7 +40,7 @@ fn test_route_length() {
 #[test]
 fn test_route_points() {
     let path = "target/debug/route_p.gpx".to_string();
-    let splitter = Box::new(RouteSplitter::new(path.clone(),
+    let splitter = Box::new(RouteSplitter::new(
     Box::new(PointsLimit::new(40))));
 
     let ctx = Context::new(path, splitter);

--- a/tests/split_it.rs
+++ b/tests/split_it.rs
@@ -1,40 +1,50 @@
-use gpx_split::split::{Splitter, TrackSplitter, RouteSplitter};
+use gpx_split::split::{Context, TrackSplitter, RouteSplitter};
 use gpx_split::limit::{LengthLimit, PointsLimit};
 
 #[test]
 fn test_track_length() {
-    let s = TrackSplitter::new(
-        "target/debug/track_l.gpx".to_string(),
-        Box::new(LengthLimit::new(1000)));
+    let path = "target/debug/track_l.gpx".to_string();
+    let splitter = Box::new(TrackSplitter::new(path.clone(),
+        Box::new(LengthLimit::new(1000))));
 
-    assert_splitted(s, 3)
+    let ctx = Context::new(path, splitter);
+    let res = ctx.run().unwrap();
+
+    assert_eq!(3, res);
 }
 
 #[test]
 fn test_track_points() {
-    let s = TrackSplitter::new(
-        "target/debug/track_p.gpx".to_string(),
-        Box::new(PointsLimit::new(50)));
-    assert_splitted(s, 2)
+    let path = "target/debug/track_p.gpx".to_string();
+    let splitter = Box::new(TrackSplitter::new(path.clone(),
+    Box::new(PointsLimit::new(50))));
+
+    let ctx = Context::new(path, splitter);
+    let res = ctx.run().unwrap();
+
+    assert_eq!(2, res);
 }
 
 #[test]
 fn test_route_length() {
-    let s = RouteSplitter::new(
-        "target/debug/route_l.gpx".to_string(),
-        Box::new(LengthLimit::new(5000)));
-    assert_splitted(s, 3)
+    let path = "target/debug/route_l.gpx".to_string();
+    let splitter = Box::new(RouteSplitter::new(path.clone(),
+    Box::new(LengthLimit::new(5000))));
+
+    let ctx = Context::new(path, splitter);
+    let res = ctx.run().unwrap();
+
+    assert_eq!(3, res);
 }
 
 #[test]
 fn test_route_points() {
-    let s = RouteSplitter::new(
-        "target/debug/route_p.gpx".to_string(),
-        Box::new(PointsLimit::new(40)));
-    assert_splitted(s, 2)
-}
+    let path = "target/debug/route_p.gpx".to_string();
+    let splitter = Box::new(RouteSplitter::new(path.clone(),
+    Box::new(PointsLimit::new(40))));
 
-fn assert_splitted<T: Splitter>(splitter: T, size: usize) {
-    let res = splitter.split().unwrap();
-    assert_eq!(size, res)
+    let ctx = Context::new(path, splitter);
+    let res = ctx.run().unwrap();
+
+    assert_eq!(2, res);
 }


### PR DESCRIPTION
Add common context for logic that repeats in all splitters.